### PR TITLE
enable Prophet debugger to detect cartridge

### DIFF
--- a/cartridges/int_klaviyo/.project
+++ b/cartridges/int_klaviyo/.project
@@ -11,7 +11,7 @@
 			</arguments>
 		</buildCommand>
 	</buildSpec>
-	<natures>
-		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
-	</natures>
+    <natures>
+        <nature>com.demandware.studio.core.beehiveNature</nature>
+    </natures>
 </projectDescription>

--- a/cartridges/int_klaviyo_core/.project
+++ b/cartridges/int_klaviyo_core/.project
@@ -11,7 +11,7 @@
 			</arguments>
 		</buildCommand>
 	</buildSpec>
-	<natures>
-		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
-	</natures>
+    <natures>
+        <nature>com.demandware.studio.core.beehiveNature</nature>
+    </natures>
 </projectDescription>

--- a/cartridges/int_klaviyo_sfra/.project
+++ b/cartridges/int_klaviyo_sfra/.project
@@ -11,7 +11,7 @@
 			</arguments>
 		</buildCommand>
 	</buildSpec>
-	<natures>
-		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
-	</natures>
+    <natures>
+        <nature>com.demandware.studio.core.beehiveNature</nature>
+    </natures>
 </projectDescription>


### PR DESCRIPTION
Prophet debugger use by. SFCC developpers, scan .project content ti deb ug cartridges : https://github.com/SqrTT/prophet/blob/0fbebd7396673bb8cd3107a9502d1d1cd08c60b7/src/lib/CartridgeHelper.ts#L44