### PR TITLE
updating terminology to events instead of emails

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/SFCC_Klaviyo.iml
+++ b/.idea/SFCC_Klaviyo.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/cartridges/int_klaviyo/cartridge/templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,24 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_PROPERTY_COLON" value="true" />
+      <option name="ALIGN_OBJECT_PROPERTIES" value="2" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="VAR_DECLARATION_WRAP" value="2" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="INDENT_CASE_FROM_SWITCH" value="false" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="IF_BRACE_FORCE" value="1" />
+      <option name="DOWHILE_BRACE_FORCE" value="1" />
+      <option name="WHILE_BRACE_FORCE" value="1" />
+      <option name="FOR_BRACE_FORCE" value="1" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/SFCC_Klaviyo.iml" filepath="$PROJECT_DIR$/.idea/SFCC_Klaviyo.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/cartridges/int_klaviyo_core/cartridge/scripts/utils/klaviyo/emailUtils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/utils/klaviyo/emailUtils.js
@@ -7,26 +7,26 @@ var productMgr = require('dw/catalog/ProductMgr');
 var imageSize = Site.getCurrent().getCustomPreferenceValue('klaviyo_image_size') || null;
 
 /**
- * Sends an order to Klaviyo with the order email type.
+ * Sends an order to Klaviyo with the order event type.
  *
  * @param order
  * @param mailType
  * @returns
  */
-function sendOrderEmail(order, mailType) {
-    var logger = Logger.getLogger('Klaviyo', 'emailUtils - sendOrderEmail()');
+function sendOrderEvent(order, mailType) {
+    var logger = Logger.getLogger('Klaviyo', 'emailUtils - sendOrderEvent()');
     try {
         var isFutureOrder = (mailType == 'Auto Delivery Order Confirmation');
         var orderPayload = prepareOrderPayload(order, isFutureOrder, mailType);
-        require('*/cartridge/scripts/utils/klaviyo/klaviyoUtils').sendEmail(order.getCustomerEmail(), orderPayload, mailType);
+        require('*/cartridge/scripts/utils/klaviyo/klaviyoUtils').sendEvent(order.getCustomerEmail(), orderPayload, mailType);
     } catch (e) {
-        logger.error('sendOrderEmail() failed for order: ' + order.getOrderNo() + ', mailType: ' + mailType + '. Error: ' + e.message);
+        logger.error('sendOrderEvent() failed for order: ' + order.getOrderNo() + ', mailType: ' + mailType + '. Error: ' + e.message);
     }
 }
 
 
 /**
- * Prepares the order in JSON format for email send.
+ * Prepares the order in JSON format for event send.
  * @param order
  * @param isFutureOrder
  * @param mailType
@@ -372,6 +372,6 @@ function prepareOrderPayload(order, isFutureOrder, mailType) {
 }
 
 module.exports = {
-    sendOrderEmail      : sendOrderEmail,
+    sendOrderEvent      : sendOrderEvent,
     prepareOrderPayload : prepareOrderPayload
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/utils/klaviyo/klaviyoUtils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/utils/klaviyo/klaviyoUtils.js
@@ -23,14 +23,14 @@ var WHITELISTED_EVENTS = ['Searched Site', 'Viewed Product', 'Viewed Category', 
  * @param event
  * @returns
  */
-function sendEmail(email, data, event) {
+function sendEvent(email, data, event) {
     var requestBody = {};
     var resultObj = {};
 
-    var logger = Logger.getLogger('Klaviyo', 'klaviyoUtils - sendEmail()');
+    var logger = Logger.getLogger('Klaviyo', 'klaviyoUtils - sendEvent()');
 
     if (KlaviyoTrackService == null || empty(email)) {
-        logger.error('sendEmail() failed for email: ' + obfuscateKlEmail(email) + '. Service Connection for send email via Klaviyo returned null.');
+        logger.error('sendEvent() failed for email: ' + obfuscateKlEmail(email) + '. Service Connection for send event to Klaviyo returned null.');
         return;
     }
 
@@ -41,16 +41,16 @@ function sendEmail(email, data, event) {
     var result = KlaviyoTrackService.call(requestBody);
 
     if (result == null) {
-        logger.error('Result for send email via Klaviyo returned null.');
+        logger.error('Result for send event to Klaviyo returned null.');
         return;
     }
 
     resultObj = JSON.parse(result.object);
 
     if (resultObj == 1) {
-        logger.info('Send email via Klaviyo is successful.');
+        logger.info('Send event to Klaviyo is successful.');
     } else {
-        logger.error('Send email via Klaviyo failed.');
+        logger.error('Send event to Klaviyo failed.');
     }
 
     return resultObj;
@@ -253,7 +253,7 @@ function prepareOrderConfirmationEventForKlaviyo(currentOrder) {
         // site specific order object */
         var emailUtils = require('*/cartridge/scripts/utils/klaviyo/emailUtils');
         var dwareOrder = emailUtils.prepareOrderPayload(currentOrder, false, 'orderConfirmation');
-        sendEmail(currentOrder.getCustomerEmail(), dwareOrder, 'Order Confirmation');
+        sendEvent(currentOrder.getCustomerEmail(), dwareOrder, 'Order Confirmation');
 
         // giftcards
         var giftCertCollection = currentOrder.getGiftCertificateLineItems().toArray();
@@ -273,7 +273,7 @@ function prepareOrderConfirmationEventForKlaviyo(currentOrder) {
         // send an event for transactional gift certificate emails
         for (var totalOrderGiftCards = 0; totalOrderGiftCards < orderGiftCards.length; totalOrderGiftCards++) {
             var theGiftCard = orderGiftCards[totalOrderGiftCards];
-            sendEmail(theGiftCard['Recipient Email'], theGiftCard, 'e-Giftcard Notification');
+            sendEvent(theGiftCard['Recipient Email'], theGiftCard, 'e-Giftcard Notification');
         }
     } catch (e) {
         logger.debug('prepareOrderConfirmationEventForKlaviyo -- error ' + e.message + ' at ' + e.lineNumber);
@@ -350,7 +350,7 @@ function sendShipmentConfirmation(orderID) {
             var order = orderList[i];
             try {
                 var emailUtils = require('*/cartridge/scripts/utils/klaviyo/emailUtils');
-                emailUtils.sendOrderEmail(order, 'Shipping Confirmation');
+                emailUtils.sendOrderEvent(order, 'Shipping Confirmation');
                 sendStatus = true;
             } catch (e) {
                 logger.error('resendKlaviyoShipmentEmailsJob failed for order: ' + order.getOrderNo() + '. Error: ' + e.message);
@@ -477,7 +477,7 @@ var trackAddToCart = function () {
         email = currentUser.email;
     }
     var event = 'Add To Cart';
-    sendEmail(email, klaviyoDataLayer, event);
+    sendEvent(email, klaviyoDataLayer, event);
 };
 
 /**
@@ -499,7 +499,7 @@ function obfuscateKlEmail(email) {
 }
 
 module.exports = {
-    sendEmail                               : sendEmail,
+    sendEvent                               : sendEvent,
     preparegiftCardObject                   : preparegiftCardObject,
     prepareViewedProductEventData           : prepareViewedProductEventData,
     prepareProductObj                       : prepareProductObj,

--- a/test/mocks/EmailUtils.js
+++ b/test/mocks/EmailUtils.js
@@ -1,9 +1,9 @@
 'use strict';
 
-function sendOrderEmail(order, confirmationType) {
+function sendOrderEvent(order, confirmationType) {
   return 1;
 }
 
 module.exports = {
-  sendOrderEmail: sendOrderEmail
+  sendOrderEvent: sendOrderEvent
 }

--- a/test/unit/KlaviyoUtils.spec.js
+++ b/test/unit/KlaviyoUtils.spec.js
@@ -46,9 +46,9 @@ describe('klaviyoUtils.js script', function() {
       $email: 'kltest@klaviyo.com'
     }
   };
-  describe('sendEmail function', function() {
+  describe('sendEvent function', function() {
     it('should return a 1 if track call succeeds', function() {
-      var trackCallResult = klaviyoUtilsFile.sendEmail(payloadObj.customer_properties.$email, {}, 'Event Name');
+      var trackCallResult = klaviyoUtilsFile.sendEvent(payloadObj.customer_properties.$email, {}, 'Event Name');
       expect(trackCallResult).to.equal(1);
     });
   });


### PR DESCRIPTION
Some customers have reached out asking why they aren't receiving emails after some functions in the cartridge are called (ie. sendEmail). Adding this to rename references to "sending emails" (old functionality) to "sending event data" (actually what they do now via track api) to reduce confusion.