### PR TITLE
Wrap SFRA page-object methods in test.step for better report output

### DIFF
--- a/test/src/tests/e2e/sfra/page-objects/checkout.js
+++ b/test/src/tests/e2e/sfra/page-objects/checkout.js
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import path from 'path'
 import { BasePage } from './base'
 import { ProductPage } from './product'
@@ -39,47 +39,57 @@ exports.CheckoutPage = class CheckoutPage extends BasePage {
     }
 
     async startCheckout() {
-        this.page.goto(`${SFRA_BASE_URL}/en_US/Checkout-Begin`)
-        await this.page.waitForTimeout(3000)
+        await test.step('Navigate to checkout begin page', async () => {
+            this.page.goto(`${SFRA_BASE_URL}/en_US/Checkout-Begin`)
+            await this.page.waitForTimeout(3000)
+        })
     }
 
     async enterGuestEmail(email) {
-        await this.page.locator(this.guestEmailInput).fill(email)
-        await this.guestCheckoutSubmit.click()
+        await test.step('Enter guest checkout email', async () => {
+            await this.page.locator(this.guestEmailInput).fill(email)
+            await this.guestCheckoutSubmit.click()
+        })
     }
 
     async submitShippingForm(){
-        await this.submitShippingLocator.click()
-        await this.page.waitForTimeout(3000)
+        await test.step('Submit shipping form', async () => {
+            await this.submitShippingLocator.click()
+            await this.page.waitForTimeout(3000)
+        })
     }
 
     async fillShippingForm(data) {
-        await this.shippingFnameLocator.fill(data.firstName)
-        await this.shippingLnameLocator.fill(data.lastName)
-        await this.shippingAddressLocator.fill(data.address)
-        await this.cityLocator.fill(data.city)
-        await this.countryLocator.locator('option')
-        await this.countryLocator.selectOption({ value: data.country })
-        await this.stateLocator.locator('option')
-        await this.stateLocator.selectOption({ value: data.state })
-        await this.postCodeLocator.fill(data.postal)
-        await this.phoneLocator.fill(data.phone)
+        await test.step('Fill shipping form', async () => {
+            await this.shippingFnameLocator.fill(data.firstName)
+            await this.shippingLnameLocator.fill(data.lastName)
+            await this.shippingAddressLocator.fill(data.address)
+            await this.cityLocator.fill(data.city)
+            await this.countryLocator.locator('option')
+            await this.countryLocator.selectOption({ value: data.country })
+            await this.stateLocator.locator('option')
+            await this.stateLocator.selectOption({ value: data.state })
+            await this.postCodeLocator.fill(data.postal)
+            await this.phoneLocator.fill(data.phone)
+        })
     }
 
     async fillPaymentForm(data) {
-        await this.cardNumberLocator.fill(data.ccn)
-        await this.page.keyboard.press('Tab')
-        const months = await this.cardExpMonth.locator('option')
-        const monthVal = await months.last().getAttribute('value')
-        await this.cardExpMonth.selectOption({ value: monthVal })
-        const years = await this.cardExpYear.locator('option')
-        const yearVal = await years.last().getAttribute('value')
-        await this.cardExpYear.selectOption({ value: yearVal })
-        await this.securityCode.fill('123')
-        await this.paymentLocator.click()
-        await this.page.waitForLoadState('networkidle')
-        await this.placeOrderLocator.click()
-        await this.page.waitForLoadState('networkidle')
+        await test.step('Fill payment form and place order', async () => {
+            await this.cardNumberLocator.fill(data.ccn)
+            await this.page.keyboard.press('Tab')
+            const months = await this.cardExpMonth.locator('option')
+            const monthVal = await months.last().getAttribute('value')
+            await this.cardExpMonth.selectOption({ value: monthVal })
+            const years = await this.cardExpYear.locator('option')
+            const yearVal = await years.last().getAttribute('value')
+            await this.cardExpYear.selectOption({ value: yearVal })
+            await this.securityCode.fill('123')
+            await this.paymentLocator.click()
+            await this.page.waitForLoadState('networkidle')
+            await this.placeOrderLocator.click()
+            await this.page.waitForLoadState('networkidle')
+        })
     }
 
     async enableEmailSubscription() {

--- a/test/src/tests/e2e/sfra/page-objects/product.js
+++ b/test/src/tests/e2e/sfra/page-objects/product.js
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import path from 'path'
 import { BasePage } from './base'
 import { AccountPage } from './account'
@@ -23,22 +23,26 @@ exports.ProductPage = class ProductPage extends BasePage {
     }
 
     async getProduct() {
-        await this.newArrivals.click()
-        await this.page.waitForTimeout(5000)
-        const categories = await this.categoryLocator
-        await categories.first().click()
-        await this.page.waitForLoadState('networkidle')
-        const products = await this.productLocator
-        await products.first().click()
-        await this.page.waitForLoadState('networkidle')
-        const productTitle = await this.productTitle.first().innerHTML()
-        return productTitle
+        return await test.step('Navigate from homepage to first product PDP and read title', async () => {
+            await this.newArrivals.click()
+            await this.page.waitForTimeout(5000)
+            const categories = await this.categoryLocator
+            await categories.first().click()
+            await this.page.waitForLoadState('networkidle')
+            const products = await this.productLocator
+            await products.first().click()
+            await this.page.waitForLoadState('networkidle')
+            const productTitle = await this.productTitle.first().innerHTML()
+            return productTitle
+        })
     }
 
     async addToCart() {
-        await this.selectSize()
-        await this.selectWidth()
-        await this.addToCartLocator.click()
+        await test.step('Select product options and add to cart', async () => {
+            await this.selectSize()
+            await this.selectWidth()
+            await this.addToCartLocator.click()
+        })
     }
 
     async selectSize() {
@@ -60,21 +64,25 @@ exports.ProductPage = class ProductPage extends BasePage {
     }
 
     async visitPDP() {
-        await this.newArrivals.click()
-        await this.page.waitForTimeout(5000)
-        const categories = await this.categoryLocator
-        await categories.first().click()
-        await this.page.waitForLoadState('networkidle')
-        const products = await this.productLocator
-        await products.first().click()
-        await this.page.waitForLoadState('networkidle')
+        await test.step('Navigate from homepage to a product PDP', async () => {
+            await this.newArrivals.click()
+            await this.page.waitForTimeout(5000)
+            const categories = await this.categoryLocator
+            await categories.first().click()
+            await this.page.waitForLoadState('networkidle')
+            const products = await this.productLocator
+            await products.first().click()
+            await this.page.waitForLoadState('networkidle')
+        })
     }
 
     async visitPLP() {
-        await this.newArrivals.click()
-        await this.page.waitForTimeout(5000)
-        const categories = await this.categoryLocator
-        await categories.first().click()
-        await this.page.waitForLoadState('networkidle')
+        await test.step('Navigate from homepage to a product listing page', async () => {
+            await this.newArrivals.click()
+            await this.page.waitForTimeout(5000)
+            const categories = await this.categoryLocator
+            await categories.first().click()
+            await this.page.waitForLoadState('networkidle')
+        })
     }
 }


### PR DESCRIPTION
## Description

Improve E2E test DX by wrapping high-level user-facing helpers on the SFRA `ProductPage` and `CheckoutPage` page objects in `test.step()` calls, so the Playwright HTML report shows clear step breakdowns for each phase of a test.

Methods wrapped:

- `ProductPage`: `getProduct`, `addToCart`, `visitPDP`, `visitPLP`
- `CheckoutPage`: `startCheckout`, `enterGuestEmail`, `submitShippingForm`, `fillShippingForm`, `fillPaymentForm`

## Why this PR differs from the parallel WooCommerce/Magento2/PrestaShop PRs

The parallel repos (see woocommerce-klaviyo#307) also add a `requestfailed` listener to catch VPN/CORS failures on browser-side calls to `a.klaviyo.com`. SFCC does not have any such browser-side Klaviyo calls — event verification is done by polling the Klaviyo V3 API from the Node test process via `checkEventWithRetry` in `utils/event-checker.js`. That path is not subject to browser-level VPN/CORS interference, so no `requestfailed` detection is needed here.

Scope is therefore limited to the `test.step` DX improvement.

## Manual Testing Steps

1. Run `npm run test:sfra:e2e -- --reporter=html` and open the report.
2. Expand a test — each high-level page-object method should appear as its own collapsible step with a friendly description instead of a flat list of locator clicks and fills.

## Pre-Submission Checklist

- [x] Test-only changes — no production cartridge files touched, no CHANGELOG entry needed.

## Related

- Parallel PR in woocommerce-klaviyo: https://github.com/klaviyo/woocommerce-klaviyo/pull/307