### PR TITLE
Bump Klaviyo V3 API revision to 2026-04-15

### DIFF
--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -10,7 +10,7 @@ var Site = require('dw/system/Site');
  * @returns {string} API version in YYYY-MM-DD format
  */
 function getApiVersion() {
-    return '2025-10-15';
+    return '2026-04-15';
 }
 
 /**


### PR DESCRIPTION
Mechanical bump of the Klaviyo V3 API `revision` constant to `2026-04-15`.

Opened as a **draft** by the `/integration-modules-revision-bump` skill. Before marking ready for review:

- [ ] Apply any breaking-change fixes called out by the audit report
- [ ] Deploy the branch to the test site
- [ ] Run e2e tests and attach results

See the audit report from `/integration-modules-revision-audit` for context on the target revision and any breaking changes.