### PR TITLE
Bump Klaviyo V3 API revision to 2026-04-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ bumped for multiple releases during one month.
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+### [26.5.0] - 2026-05-01
+
 #### Changed
 - Updates to Klaviyo API revision 2026-04-15. See https://developers.klaviyo.com/en/docs/changelog_
 
@@ -122,7 +124,8 @@ bumped for multiple releases during one month.
 <!-- END RELEASE NOTES -->
 
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.11.0...HEAD
+[Unreleased]: https://github.com/klaviyo/SFCC_Klaviyo/compare/26.5.0...HEAD
+[26.5.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.11.0...26.5.0
 [25.11.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.8.0...25.11.0
 [25.8.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.7.0...25.8.0
 [25.7.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.4.0...25.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ bumped for multiple releases during one month.
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Changed
+- Updates to Klaviyo API revision 2026-04-15. See https://developers.klaviyo.com/en/docs/changelog_
+
 ### [25.11.0] - 2025-11-04
 
 #### Changed

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -10,7 +10,7 @@ var Site = require('dw/system/Site');
  * @returns {string} API version in YYYY-MM-DD format
  */
 function getApiVersion() {
-    return '2025-10-15';
+    return '2026-04-15';
 }
 
 /**

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -18,7 +18,7 @@ function getApiVersion() {
  * @returns {string} User-Agent string
  */
 function getUserAgent() {
-    return 'sfcc-klaviyo/25.11.0';
+    return 'sfcc-klaviyo/26.5.0';
 }
 
 // HTTP Services

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "int_klaviyo",
-  "version": "24.9.0",
+  "version": "26.5.0",
   "description": "Klaviyo integration for Commerce Cloud",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Mechanical bump of the Klaviyo V3 API \`revision\` constant to \`2026-04-15\`.

Opened as a **draft** by the \`/integrations-self-hosted:integration-modules-revision-bump\` skill. Before marking ready for review:

- [x] Apply any breaking-change fixes called out by the audit report — run \`/integrations-self-hosted:integration-modules-revision-migrate 2026-04-15 --audit-report <path>\` or author manually on this branch.
- [x] Deploy the branch to the test site.
- [x] Run e2e tests and attach results.

See the audit report from \`/integrations-self-hosted:integration-modules-revision-audit\` for context on the target revision and any breaking changes.