### PR TITLE
Add Window Var for SFCC Architecture

### DIFF
--- a/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -9,10 +9,11 @@
         !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
     </script>
     <iscomment>
-        Exposes the active SFCC Site ID on window so klaviyo.js consumers (e.g. customer hub) can scope requests to the correct site.
+        Exposes SFCC storefront context on window so klaviyo.js consumers (e.g. customer hub) can identify the active site and architecture.
     </iscomment>
     <script>
         window.klaviyoSFCCSiteID = "${klaviyoUtils.siteId}";
+        window.klaviyoSFCCArchitecture = 'site-genesis';
     </script>
     <isif condition="${pageContext.type == 'product' ||
         pageContext.type == 'search' ||

--- a/cartridges/int_klaviyo_sfra/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo_sfra/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -14,10 +14,11 @@
         !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
     </script>
     <iscomment>
-        Exposes the active SFCC Site ID on window so klaviyo.js consumers (e.g. customer hub) can scope requests to the correct site.
+        Exposes SFCC storefront context on window so klaviyo.js consumers (e.g. customer hub) can identify the active site and architecture.
     </iscomment>
     <script>
         window.klaviyoSFCCSiteID = "${klaviyoUtils.siteId}";
+        window.klaviyoSFCCArchitecture = 'sfra';
     </script>
     <isif condition="${pdict.action == 'Product-Show' ||
         pdict.action == 'Search-Show' ||


### PR DESCRIPTION
Adding a window var so onsite client can tell what architecture (SFRA vs Site Genesis) the current storefront is. This is in addition to the site ID that we added previously