### PR TITLE
Add profile recently viewed product tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ bumped for multiple releases during one month.
 
 #### Added
 - Adds window variable to enable Klaviyo Customer Hub
+- Recently-viewed product tracking on PDPs via `klaviyo.trackViewedItem`, piggybacking on the existing `Klaviyo-Event` remote include. Honors the `klaviyo_use_variation_group_id` site preference. Only fires for identified visitors.
 
 #### Changed
 - Wire existing mocha unit suite into the CI workflow so it runs on every pull request. Pins Node 20 via `.nvmrc`, commits `test/package-lock.json` for reproducible `npm ci`, and switches the `dw-api-mock` dependency to an HTTPS tarball so Actions runners can install without an SSH key.

--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -50,10 +50,17 @@ var Event = function () {
                 serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, action, false);
                 if (isKlDebugOn) {
                     app.getView({
-                        klDebugData     : klaviyoUtils.prepareDebugData(dataObj),
-                        serviceCallData : klaviyoUtils.prepareDebugData(serviceCallResult)
+                        klDebugData           : klaviyoUtils.prepareDebugData(dataObj),
+                        serviceCallData       : klaviyoUtils.prepareDebugData(serviceCallResult),
+                        klSkipTrackViewedItem : (action === klaviyoUtils.EVENT_NAMES.viewedProduct)
                     }).render('klaviyo/klaviyoDebug');
                     return;
+                }
+                if (action === klaviyoUtils.EVENT_NAMES.viewedProduct) {
+                    var viewedItemPayload = klaviyoUtils.buildTrackViewedItemPayload(dataObj);
+                    app.getView({
+                        klViewedItemData: klaviyoUtils.prepareDebugData(viewedItemPayload)
+                    }).render('klaviyo/klaviyoTrackViewedItem');
                 }
             }
         } else {

--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -58,9 +58,11 @@ var Event = function () {
                 }
                 if (action === klaviyoUtils.EVENT_NAMES.viewedProduct) {
                     var viewedItemPayload = klaviyoUtils.buildTrackViewedItemPayload(dataObj);
-                    app.getView({
-                        klViewedItemData: klaviyoUtils.prepareDebugData(viewedItemPayload)
-                    }).render('klaviyo/klaviyoTrackViewedItem');
+                    if (viewedItemPayload) {
+                        app.getView({
+                            klViewedItemData: klaviyoUtils.prepareDebugData(viewedItemPayload)
+                        }).render('klaviyo/klaviyoTrackViewedItem');
+                    }
                 }
             }
         } else {

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -84,7 +84,7 @@ function prepareDebugData(obj) {
 // klaviyo_image_size preference via getImage). Called only when action is
 // 'Viewed Product' and an exchangeID is present.
 function buildTrackViewedItemPayload(dataObj) {
-    if (!dataObj) {
+    if (!dataObj || !dataObj['Product ID']) {
         return null;
     }
     return {

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -76,6 +76,30 @@ function prepareDebugData(obj) {
 }
 
 
+// Builds the trimmed payload for the client-side klaviyo.trackViewedItem() SDK call
+// from the same dataObj already produced by eventData/viewedProduct.js for the
+// server-side Viewed Product event. Piggybacking on the existing dataObj means no
+// extra product fetch and guarantees the two events stay in sync (e.g. both honor
+// the klaviyo_use_variation_group_id preference via getParentProduct and the
+// klaviyo_image_size preference via getImage). Called only when action is
+// 'Viewed Product' and an exchangeID is present.
+function buildTrackViewedItemPayload(dataObj) {
+    if (!dataObj) {
+        return null;
+    }
+    return {
+        Title      : dataObj['Product Name'],
+        ItemId     : dataObj['Product ID'],
+        Categories : dataObj['Categories'],
+        ImageUrl   : dataObj['Product Image URL'],
+        Url        : dataObj['Product Page URL'],
+        Metadata   : {
+            Price: dataObj['Price']
+        }
+    };
+}
+
+
 // Returns true if the given service result error code is in the 4xx range,
 // which means Klaviyo IS responding -- it's just rejecting our request (e.g.
 // invalid payload). Distinguishes "bad payload" from "Klaviyo is unresponsive"
@@ -551,6 +575,7 @@ module.exports = {
     getKlaviyoExchangeID  : getKlaviyoExchangeID,
     getProfileInfo        : getProfileInfo,
     prepareDebugData      : prepareDebugData,
+    buildTrackViewedItemPayload : buildTrackViewedItemPayload,
     dedupeArray           : dedupeArray,
     getParentProduct      : getParentProduct,
     captureProductOptions : captureProductOptions,

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoDebug.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoDebug.isml
@@ -10,6 +10,9 @@
     console.log('Klaviyo Event Data: ', debugData);
     var serviceCallData = JSON.parse(atob('${pdict.serviceCallData}'));
     console.log('Klaviyo Service Result: ', serviceCallData);
+    <isif condition="${pdict.klSkipTrackViewedItem}">
+    console.log('Klaviyo Debug: trackViewedItem skipped (kldebug=true on Viewed Product).');
+    </isif>
 
     window.addEventListener("load", (event) => {
         $('body').on('product:afterAddToCart', function(evt, data){

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoTrackViewedItem.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoTrackViewedItem.isml
@@ -1,0 +1,17 @@
+<iscomment>
+    The JS in this template calls klaviyo.trackViewedItem() to persist the currently-viewed
+    product in the visitor's Klaviyo "recently viewed items" feed. It piggybacks on the
+    existing Klaviyo-Event remote include and is rendered by the SiteGen and SFRA Klaviyo
+    controllers when the action is 'Viewed Product' and an exchangeID is present.
+    The payload is base64-encoded server-side via klaviyoUtils.prepareDebugData() to keep
+    JSON safely embeddable in an inline <script>.
+</iscomment>
+<!--- TEMPLATENAME: klaviyoTrackViewedItem.isml --->
+<isif condition="${pdict.klViewedItemData}">
+    <script>
+        (function () {
+            var data = JSON.parse(atob('${pdict.klViewedItemData}'));
+            klaviyo.trackViewedItem(data);
+        })();
+    </script>
+</isif>

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
@@ -54,7 +54,14 @@ server.get('Event', function (req, res, next) {
                 if (isKlDebugOn) {
                     res.viewData.klDebugData = klaviyoUtils.prepareDebugData(dataObj);
                     res.viewData.serviceCallData = klaviyoUtils.prepareDebugData(serviceCallResult);
+                    res.viewData.klSkipTrackViewedItem = (action === klaviyoUtils.EVENT_NAMES.viewedProduct);
                     res.render('klaviyo/klaviyoDebug');
+                    next();
+                    return;
+                }
+                if (action === klaviyoUtils.EVENT_NAMES.viewedProduct) {
+                    res.viewData.klViewedItemData = klaviyoUtils.prepareDebugData(klaviyoUtils.buildTrackViewedItemPayload(dataObj));
+                    res.render('klaviyo/klaviyoTrackViewedItem');
                     next();
                     return;
                 }

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
@@ -60,10 +60,13 @@ server.get('Event', function (req, res, next) {
                     return;
                 }
                 if (action === klaviyoUtils.EVENT_NAMES.viewedProduct) {
-                    res.viewData.klViewedItemData = klaviyoUtils.prepareDebugData(klaviyoUtils.buildTrackViewedItemPayload(dataObj));
-                    res.render('klaviyo/klaviyoTrackViewedItem');
-                    next();
-                    return;
+                    var viewedItemPayload = klaviyoUtils.buildTrackViewedItemPayload(dataObj);
+                    if (viewedItemPayload) {
+                        res.viewData.klViewedItemData = klaviyoUtils.prepareDebugData(viewedItemPayload);
+                        res.render('klaviyo/klaviyoTrackViewedItem');
+                        next();
+                        return;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Description
This PR reintroduces the "Recently Viewed Item" metric which is sent client-side via the klaviyo onsite javascript. This was removed in our last major cartridge refactor https://github.com/klaviyo/SFCC_Klaviyo/releases#release-23.7.0 when we moved all event processing to the server-side. Because this is a key feature for the customer hub release we are reintroducing it. When a PDP page is hit, we emit the Viewed Product event from the server-side, then send a pared-back data dictionary to the frontend by rendering the new [klaviyoTrackViewedItem.isml‎](https://github.com/klaviyo/SFCC_Klaviyo/pull/74/changes#diff-cd1ece5f3b3119098a0dcd1e7700737ac6a28d9192a84b37726a636ff9c43fcc) template. This will only occur if the klaviyo cartridge is enabled, the user is identified, and we have valid event data. 

What to expect - when the new version of the cartridge is installed, per-profile Recently Viewed Items will be visible in the klaviyo UI. These can also be used in templates via the `person.ViewedItems` property. 

<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide steps to recreate.
-->

1. Uploaded cartridge to test SFRA site - validated that for cookied users we see the Recently Viewed Items populate on the profile with the correct data: 
<img width="1197" height="877" alt="image" src="https://github.com/user-attachments/assets/53793729-dffb-4550-96e1-ec0e9a309e8e" />

2. Validated all other events are firing as expected ✅ 

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/SFCC_Klaviyo#making-updates)

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
