### PR TITLE
use order.currencyCode instead of session value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bumped for multiple releases during one month.
 - Wire existing mocha unit suite into the CI workflow so it runs on every pull request. Pins Node 20 via `.nvmrc`, commits `test/package-lock.json` for reproducible `npm ci`, and switches the `dw-api-mock` dependency to an HTTPS tarball so Actions runners can install without an SSH key.
 
 #### Fixed
+- Order Confirmation events now use `order.currencyCode` instead of session currency (including line-item price formatting via `priceCheck` / `captureBonusProduct` / `captureProductOptions`), so `value_currency` and formatted money fields stay correct when the event is sent from a Job outside the shopper session.
 - Wraps Klaviyo service calls in `try/catch` so a Klaviyo API outage cannot break checkout. `trackEvent` returns `{ success: false }` on connection errors, timeouts, 5xx responses, or any thrown exception; `subscribeUser` no longer throws on null service responses.
 - `subscribeUser` skips the SMS subscribe when the email call indicates Klaviyo is unresponsive (null, 5xx, or thrown exception), to avoid burning a second timeout window on a known-down service. 4xx responses still allow the SMS attempt.
 - Klaviyo service-call error logs now include the HTTP status code, exception name, and stack, and classify failures as `4xx rejected` vs `unavailable (5xx)` so support can tell "Klaviyo is down" from "we sent a bad payload" at a glance.

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -20,6 +20,9 @@ function getData(order) {
     try {
         data = {};
         klaviyoUtils.setSiteIdAndIntegrationInfo(data, siteId);
+        // Use order.currencyCode (not session) so currency is correct when this
+        // event is sent from a Job after payment, outside the shopper session.
+        var currencyCode = order.currencyCode;
         // Billing Address
         var orderBillingAddressFirstName = order.billingAddress.firstName ? order.billingAddress.firstName : '';
         var orderBillingAddressLastName = order.billingAddress.lastName ? order.billingAddress.lastName : '';
@@ -132,19 +135,19 @@ function getData(order) {
                     currentLineItem['Master Product ID'] = parentProduct.ID;
                 }
 
-                var priceData = klaviyoUtils.priceCheck(productLineItem, productDetail);
+                var priceData = klaviyoUtils.priceCheck(productLineItem, productDetail, currencyCode);
                 currentLineItem['Price'] = priceData.purchasePrice;
                 currentLineItem['Price Value'] = priceData.purchasePriceValue;
                 currentLineItem['Original Price'] = priceData.originalPrice;
                 currentLineItem['Original Price Value'] = priceData.originalPriceValue;
 
-                var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
+                var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems, currencyCode) : null;
                 if (selectedOptions && selectedOptions.length) {
                     currentLineItem['Product Options'] = selectedOptions;
                 }
 
                 if (productLineItem.bonusProductLineItem) {
-                    var bonusProduct = klaviyoUtils.captureBonusProduct(productLineItem, productDetail);
+                    var bonusProduct = klaviyoUtils.captureBonusProduct(productLineItem, productDetail, currencyCode);
                     currentLineItem['Is Bonus Product'] = bonusProduct.isbonusProduct;
                     currentLineItem['Original Price'] = bonusProduct.originalPrice;
                     currentLineItem['Original Price Value'] = bonusProduct.originalPriceValue;
@@ -204,18 +207,18 @@ function getData(order) {
 
             // discounts
             var orderDiscount = merchTotalExclOrderDiscounts.subtract(merchTotalInclOrderDiscounts);
-            var orderDiscountString = dw.util.StringUtils.formatMoney(dw.value.Money(orderDiscount.value, session.getCurrency().getCurrencyCode()));
+            var orderDiscountString = dw.util.StringUtils.formatMoney(dw.value.Money(orderDiscount.value, currencyCode));
 
             // Sub Total
             var subTotal = merchTotalInclOrderDiscounts;
-            var subTotalString = dw.util.StringUtils.formatMoney(dw.value.Money(subTotal.value, session.getCurrency().getCurrencyCode()));
+            var subTotalString = dw.util.StringUtils.formatMoney(dw.value.Money(subTotal.value, currencyCode));
 
             // Shipping
             var shippingExclDiscounts = order.shippingTotalPrice;
             var shippingInclDiscounts = order.getAdjustedShippingTotalPrice();
             var shippingDiscount = shippingExclDiscounts.subtract(shippingInclDiscounts);
             var shippingTotalCost = shippingExclDiscounts.subtract(shippingDiscount);
-            var shippingTotalCostString = dw.util.StringUtils.formatMoney(dw.value.Money(shippingTotalCost.value, session.getCurrency().getCurrencyCode()));
+            var shippingTotalCostString = dw.util.StringUtils.formatMoney(dw.value.Money(shippingTotalCost.value, currencyCode));
 
             // Tax
             var totalTax = 0.0;
@@ -223,7 +226,7 @@ function getData(order) {
                 totalTax = order.totalTax.value;
             }
             var totalTaxString = dw.util.StringUtils.formatMoney(
-                dw.value.Money(totalTax, session.getCurrency().getCurrencyCode())
+                dw.value.Money(totalTax, currencyCode)
             );
 
             // Order Total
@@ -232,7 +235,7 @@ function getData(order) {
                 orderTotal = order.totalNetPrice.value + totalTax;
             }
             var orderTotalString = dw.util.StringUtils.formatMoney(
-                dw.value.Money(orderTotal, session.getCurrency().getCurrencyCode())
+                dw.value.Money(orderTotal, currencyCode)
             );
 
             data['Order Total'] = orderTotalString;
@@ -296,7 +299,7 @@ function getData(order) {
         data['Item Primary Categories'] = itemPrimaryCategories;
         data['Item Categories'] = klaviyoUtils.dedupeArray(itemCategories);
         data['value'] = orderTotal;
-        data['value_currency'] = session.getCurrency().getCurrencyCode();
+        data['value_currency'] = currencyCode;
         data['$event_id'] = 'orderConfirmation-' + order.orderNo;
         data['Tracking Number'] = order.shipments[0].trackingNumber ? order.shipments[0].trackingNumber : '';
     } catch (e) {

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -196,12 +196,14 @@ function getParentProduct(product) {
 
 // helper function to extract product options and return each selected option into an object with five keys: 'Line Item Text', 'Option ID' and 'Option Value ID', 'Option Price' and 'Option Price Value.
 // This helper accomodates products that may have been configured with or feature multiple options by returning an array of each selected product option as its own optionObj.
-function captureProductOptions(prodOptions) {
+// Optional currencyCode overrides session currency (needed when Order Confirmation runs outside the shopper session).
+function captureProductOptions(prodOptions, currencyCode) {
     var options = Array.isArray(prodOptions) ? prodOptions : Array.from(prodOptions);
     var selectedOptions = [];
+    var code = currencyCode || session.getCurrency().getCurrencyCode();
 
     options.forEach(function (optionObj) {
-        var formattedOptionPrice = optionObj ? StringUtils.formatMoney(dw.value.Money(optionObj.basePrice.value, session.getCurrency().getCurrencyCode())) : null;
+        var formattedOptionPrice = optionObj ? StringUtils.formatMoney(dw.value.Money(optionObj.basePrice.value, code)) : null;
         selectedOptions.push({
             'Line Item Text'     : optionObj.lineItemText,
             'Option ID'          : optionObj.optionID,
@@ -232,12 +234,14 @@ function captureProductBundles(bundledProducts) {
 
 // helper function to handle bonus products & set appropriate properties on a returned object.
 // Used in two key tracked events: 'Started Checkout' and 'Order Confirmation'.
-function captureBonusProduct(lineItemObj, prodObj) {
+// Optional currencyCode overrides session currency (needed when Order Confirmation runs outside the shopper session).
+function captureBonusProduct(lineItemObj, prodObj, currencyCode) {
+    var code = currencyCode || session.getCurrency().getCurrencyCode();
     var bonusProductData = {};
     bonusProductData.isbonusProduct = true;
-    bonusProductData.originalPrice = StringUtils.formatMoney(dw.value.Money(prodObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode()));
+    bonusProductData.originalPrice = StringUtils.formatMoney(dw.value.Money(prodObj.getPriceModel().getPrice().value, code));
     bonusProductData.originalPriceValue = prodObj.getPriceModel().getPrice().value;
-    bonusProductData.price = StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode()));
+    bonusProductData.price = StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, code));
     bonusProductData.priceValue = lineItemObj.adjustedPrice.value;
 
     return bonusProductData;
@@ -246,22 +250,24 @@ function captureBonusProduct(lineItemObj, prodObj) {
 
 // helper function to consider promos & set Price and Original Pride properties on a returned object.
 // Used in order level events: 'Started Checkout' and 'Order Confirmation'.
-function priceCheck(lineItemObj, basketProdObj) {
+// Optional currencyCode overrides session currency (needed when Order Confirmation runs outside the shopper session).
+function priceCheck(lineItemObj, basketProdObj, currencyCode) {
+    var code = currencyCode || session.getCurrency().getCurrencyCode();
     var priceModel = basketProdObj ? basketProdObj.getPriceModel() : null;
     var priceBook = priceModel ? getRootPriceBook(priceModel.priceInfo.priceBook) : null;
     var priceBookPrice = priceBook && priceModel ? priceModel.getPriceBookPrice(priceBook.ID) : null;
     var priceData = {};
 
-    var adjustedPromoPrice = lineItemObj && lineItemObj.adjustedPrice < priceBookPrice ? StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode())) : null;
+    var adjustedPromoPrice = lineItemObj && lineItemObj.adjustedPrice < priceBookPrice ? StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, code)) : null;
     if (adjustedPromoPrice) {
-        priceData.purchasePrice = StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode()));
+        priceData.purchasePrice = StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, code));
         priceData.purchasePriceValue = lineItemObj.adjustedPrice.value;
-        priceData.originalPrice = priceBookPrice ? StringUtils.formatMoney(dw.value.Money(priceBookPrice.value, session.getCurrency().getCurrencyCode())) : StringUtils.formatMoney(dw.value.Money(basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode()));
+        priceData.originalPrice = priceBookPrice ? StringUtils.formatMoney(dw.value.Money(priceBookPrice.value, code)) : StringUtils.formatMoney(dw.value.Money(basketProdObj.getPriceModel().getPrice().value, code));
         priceData.originalPriceValue = priceBookPrice.value;
     } else {
-        priceData.purchasePrice = lineItemObj ? StringUtils.formatMoney(dw.value.Money(lineItemObj.price.value, session.getCurrency().getCurrencyCode())) : null;
+        priceData.purchasePrice = lineItemObj ? StringUtils.formatMoney(dw.value.Money(lineItemObj.price.value, code)) : null;
         priceData.purchasePriceValue = lineItemObj ? lineItemObj.price.value : null;
-        priceData.originalPrice = basketProdObj ? StringUtils.formatMoney(dw.value.Money(basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode())) : null;
+        priceData.originalPrice = basketProdObj ? StringUtils.formatMoney(dw.value.Money(basketProdObj.getPriceModel().getPrice().value, code)) : null;
         priceData.originalPriceValue = basketProdObj.getPriceModel().getPrice().value;
     }
 

--- a/test/src/tests/mocks/BasketMgr.js
+++ b/test/src/tests/mocks/BasketMgr.js
@@ -77,6 +77,7 @@ class BasketMgr {
         this.orderNo = '000101899'
         this.customerNo = this.getCustomer().ID
         this.customerName = this.getCustomer().name
+        this.currencyCode = 'USD'
     }
 
     getCustomer = () => {

--- a/test/src/tests/unit/order-confirmation.test.js
+++ b/test/src/tests/unit/order-confirmation.test.js
@@ -34,17 +34,36 @@ global.dw = {
     },
 }
 
-global.session = {
-    getCurrency: function() {
-        return {
-            getCurrencyCode: function() {
-                return 'USD'
-            }
+// Preserve session.custom for other suites (e.g. subscribeUser) that share global.session.
+global.session = global.session || {}
+global.session.custom = global.session.custom || {}
+global.session.getCurrency = function() {
+    return {
+        getCurrencyCode: function() {
+            return 'USD'
         }
     }
 }
+
 const getParentProductStub = sinon.stub()
 const basketManagerMock = new BasketMgr(true)
+const stubs = basketStubs()
+const productOpts = stubs.productOpts
+
+const priceCheckStub = sinon.stub().returns({
+    purchasePrice: 96,
+    purchasePriceValue: 1,
+    originalPrice: 100,
+    originalPriceValue: 99
+})
+const captureProductOptionsStub = sinon.stub().returns(productOpts)
+const captureBonusProductStub = sinon.stub().returns({
+    isbonusProduct: true,
+    originalPrice: 100,
+    originalPriceValue: 99,
+    price: 96,
+    priceValue: 1
+})
 
 const orderConfirmationEvent = proxyquire('int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js', {
     'dw/system/Site': Site,
@@ -55,10 +74,10 @@ const orderConfirmationEvent = proxyquire('int_klaviyo_core/cartridge/scripts/kl
     '*/cartridge/scripts/klaviyo/utils': {
         KLImageSize: 'large',
         siteId: Site.getCurrent().getID(),
-        captureProductOptions: basketStubs().pdctLineItems,
-        captureBonusProduct: basketStubs().bonusPdct,
-        captureProductBundles: basketStubs().bundlePdct,
-        priceCheck: basketStubs().priceCheckMock,
+        captureProductOptions: captureProductOptionsStub,
+        captureBonusProduct: captureBonusProductStub,
+        captureProductBundles: stubs.bundlePdct,
+        priceCheck: priceCheckStub,
         dedupeArray: function() {
             return ['Skin Care']
         },
@@ -75,6 +94,17 @@ describe('int_klaviyo_core/cartridge/scripts/klaviyo/eventData => orderConfirmat
 
     beforeEach(() => {
         global.empty.returns(false)
+        basketManagerMock.currencyCode = 'USD'
+        global.session.getCurrency = function() {
+            return {
+                getCurrencyCode: function() {
+                    return 'USD'
+                }
+            }
+        }
+        priceCheckStub.resetHistory()
+        captureProductOptionsStub.resetHistory()
+        captureBonusProductStub.resetHistory()
     })
 
     it('should return event data for "Order Confirmation" event', () => {
@@ -179,5 +209,28 @@ describe('int_klaviyo_core/cartridge/scripts/klaviyo/eventData => orderConfirmat
 
         const resultsObj = orderConfirmationEvent.getData(basketManagerMock)
         expect(resultsObj).to.deep.equal(expectedResult)
+    })
+
+    // IES-235: payment integrations may fire Order Confirmation from a Job where
+    // session currency is the site default, not the order currency.
+    it('should use order.currencyCode for value_currency and line-item helpers when session currency differs', () => {
+        basketManagerMock.currencyCode = 'EUR'
+        global.session.getCurrency = function() {
+            return {
+                getCurrencyCode: function() {
+                    return 'USD'
+                }
+            }
+        }
+
+        const resultsObj = orderConfirmationEvent.getData(basketManagerMock)
+
+        expect(resultsObj.value_currency).to.equal('EUR')
+        expect(priceCheckStub.calledOnce).to.be.true
+        expect(priceCheckStub.firstCall.args[2]).to.equal('EUR')
+        expect(captureProductOptionsStub.calledOnce).to.be.true
+        expect(captureProductOptionsStub.firstCall.args[1]).to.equal('EUR')
+        expect(captureBonusProductStub.calledOnce).to.be.true
+        expect(captureBonusProductStub.firstCall.args[2]).to.equal('EUR')
     })
 })

--- a/test/src/tests/unit/utils.test.js
+++ b/test/src/tests/unit/utils.test.js
@@ -29,4 +29,98 @@ describe('klaviyoUtils', () => {
             });
         });
     });
+
+    describe('currency helpers (IES-235)', () => {
+        const optionLineItems = [{
+            lineItemText: 'Gift Wrap',
+            optionID: 'giftWrap',
+            optionValueID: 'yes',
+            basePrice: { value: 5 }
+        }]
+
+        const lineItem = {
+            adjustedPrice: { value: 10 },
+            price: { value: 12 }
+        }
+
+        const product = {
+            getPriceModel: function() {
+                return {
+                    getPrice: function() {
+                        return { value: 20 }
+                    },
+                    // priceInfo.priceBook must be present so priceCheck can resolve a root book
+                    priceInfo: {
+                        priceBook: {}
+                    },
+                    getPriceBookPrice: function() {
+                        return null
+                    }
+                }
+            }
+        }
+
+        let previousSession
+        let previousDw
+
+        beforeEach(() => {
+            previousSession = global.session
+            previousDw = global.dw
+            global.session = {
+                getCurrency: function() {
+                    return {
+                        getCurrencyCode: function() {
+                            return 'USD'
+                        }
+                    }
+                }
+            }
+            global.dw = {
+                value: {
+                    Money: function(value, currencyCode) {
+                        return { value: value, currencyCode: currencyCode }
+                    }
+                }
+            }
+        })
+
+        afterEach(() => {
+            global.session = previousSession
+            global.dw = previousDw
+        })
+
+        it('captureProductOptions should use the provided currencyCode over session', () => {
+            const options = utils.captureProductOptions(optionLineItems, 'EUR')
+            expect(options[0]['Option Price'].currencyCode).to.equal('EUR')
+        })
+
+        it('captureProductOptions should fall back to session currency when currencyCode is omitted', () => {
+            const options = utils.captureProductOptions(optionLineItems)
+            expect(options[0]['Option Price'].currencyCode).to.equal('USD')
+        })
+
+        it('captureBonusProduct should use the provided currencyCode over session', () => {
+            const bonus = utils.captureBonusProduct(lineItem, product, 'EUR')
+            expect(bonus.originalPrice.currencyCode).to.equal('EUR')
+            expect(bonus.price.currencyCode).to.equal('EUR')
+        })
+
+        it('captureBonusProduct should fall back to session currency when currencyCode is omitted', () => {
+            const bonus = utils.captureBonusProduct(lineItem, product)
+            expect(bonus.originalPrice.currencyCode).to.equal('USD')
+            expect(bonus.price.currencyCode).to.equal('USD')
+        })
+
+        it('priceCheck should use the provided currencyCode over session', () => {
+            const priceData = utils.priceCheck(lineItem, product, 'EUR')
+            expect(priceData.purchasePrice.currencyCode).to.equal('EUR')
+            expect(priceData.originalPrice.currencyCode).to.equal('EUR')
+        })
+
+        it('priceCheck should fall back to session currency when currencyCode is omitted', () => {
+            const priceData = utils.priceCheck(lineItem, product)
+            expect(priceData.purchasePrice.currencyCode).to.equal('USD')
+            expect(priceData.originalPrice.currencyCode).to.equal('USD')
+        })
+    })
 });


### PR DESCRIPTION
## Summary
- Use `order.currencyCode` instead of session currency on Order Confirmation (including line-item price helpers), so currency stays correct when the event fires from a Job.

## Test plan
- [x] Unit tests pass
- [X] tested on sandbox - validated currency code is correct for all events
## Pre-Submission Checklist:

- [X] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/SFCC_Klaviyo#making-updates)

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
