### PR TITLE
Release version 26.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ bumped for multiple releases during one month.
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+### [26.7.0] - 2026-07-17
+
 #### Added
-- Adds window variable to enable Klaviyo Customer Hub
+- Adds `klaviyoSFCCSiteID` window variable to enable Klaviyo Customer Hub
 - Adds `int_klaviyo_customer_hub_sfra` cartridge for Customer Hub session auth and storefront routes (only needed for Customer Hub product)
 - Adds `klaviyo_customer_hub_storefront_context` site preference and `KlaviyoCustomerHubOnsiteService`
 - Recently-viewed product tracking on PDPs via `klaviyo.trackViewedItem`, piggybacking on the existing `Klaviyo-Event` remote include. Honors the `klaviyo_use_variation_group_id` site preference. Only fires for identified visitors.
@@ -139,7 +141,8 @@ bumped for multiple releases during one month.
 <!-- END RELEASE NOTES -->
 
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/SFCC_Klaviyo/compare/26.5.0...HEAD
+[Unreleased]: https://github.com/klaviyo/SFCC_Klaviyo/compare/26.7.0...HEAD
+[26.7.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/26.5.0...26.7.0
 [26.5.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.11.0...26.5.0
 [25.11.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.8.0...25.11.0
 [25.8.0]: https://github.com/klaviyo/SFCC_Klaviyo/compare/25.7.0...25.8.0

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -18,7 +18,7 @@ function getApiVersion() {
  * @returns {string} User-Agent string
  */
 function getUserAgent() {
-    return 'sfcc-klaviyo/26.5.0';
+    return 'sfcc-klaviyo/26.7.0';
 }
 
 // HTTP Services


### PR DESCRIPTION
## Description
Releases version 26.7.0

Changelog below: 
### [26.7.0] - 2026-07-17

#### Added
- Adds `klaviyoSFCCSiteID` window variable to enable Klaviyo Customer Hub
- Adds `int_klaviyo_customer_hub_sfra` cartridge for Customer Hub session auth and storefront routes (only needed for Customer Hub product)
- Adds `klaviyo_customer_hub_storefront_context` site preference and `KlaviyoCustomerHubOnsiteService`
- Recently-viewed product tracking on PDPs via `klaviyo.trackViewedItem`, piggybacking on the existing `Klaviyo-Event` remote include. Honors the `klaviyo_use_variation_group_id` site preference. Only fires for identified visitors.

#### Changed
- Wire existing mocha unit suite into the CI workflow so it runs on every pull request. Pins Node 20 via `.nvmrc`, commits `test/package-lock.json` for reproducible `npm ci`, and switches the `dw-api-mock` dependency to an HTTPS tarball so Actions runners can install without an SSH key.

#### Fixed
- Order Confirmation events now use `order.currencyCode` instead of session currency (including line-item price formatting via `priceCheck` / `captureBonusProduct` / `captureProductOptions`), so `value_currency` and formatted money fields stay correct when the event is sent from a Job outside the shopper session.
- Wraps Klaviyo service calls in `try/catch` so a Klaviyo API outage cannot break checkout. `trackEvent` returns `{ success: false }` on connection errors, timeouts, 5xx responses, or any thrown exception; `subscribeUser` no longer throws on null service responses.
- `subscribeUser` skips the SMS subscribe when the email call indicates Klaviyo is unresponsive (null, 5xx, or thrown exception), to avoid burning a second timeout window on a known-down service. 4xx responses still allow the SMS attempt.
- Klaviyo service-call error logs now include the HTTP status code, exception name, and stack, and classify failures as `4xx rejected` vs `unavailable (5xx)` so support can tell "Klaviyo is down" from "we sent a bad payload" at a glance.
- Restructures `Logger.getLogger` categories across the Klaviyo cartridges to a proper Log4j dot hierarchy (`Klaviyo.<core|sfra|siteGen>.<file>.<function>`), so BM Custom Log Settings admins can filter at any granularity (`custom.Klaviyo`, `custom.Klaviyo.core`, `custom.Klaviyo.core.utils`, or `custom.Klaviyo.core.utils.trackEvent`) instead of only "all Klaviyo or nothing". The `Klaviyo` prefix and `custom-Klaviyo-*.log` file name are preserved for backwards compatibility with existing Custom Log Settings.

<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/SFCC_Klaviyo#making-updates)

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
