### PR TITLE
updates gh action so customerHub is not included in SG release artifact

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -76,10 +76,10 @@ jobs:
         run: |
           rm -r ${{ matrix.version }}/_sitegen ${{ matrix.version }}/cartridges/int_klaviyo
 
-      - name: Remove SFRA cartridge for SiteGenesis version
+      - name: Remove SFRA cartridges for SiteGenesis version
         if: matrix.version == 'klaviyoSG'
         run: |
-          rm -r ${{ matrix.version }}/cartridges/int_klaviyo_sfra
+          rm -r ${{ matrix.version }}/cartridges/int_klaviyo_sfra ${{ matrix.version }}/cartridges/int_klaviyo_customer_hub_sfra
 
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.1


### PR DESCRIPTION
## Description
Remove the customer hub cartridge from the SiteGenesis release artifact - it should only be included in the SFRA cartridge release. 
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/SFCC_Klaviyo#making-updates)

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
